### PR TITLE
Fix for Valheim Update - broke teleporting and map

### DIFF
--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -104,7 +104,9 @@ public static class Map
 		}
 
 		Minimap Minimap = Minimap.instance;
-		Minimap.PinData? closestPin = Minimap.GetClosestPin(Minimap.ScreenToWorldPoint(Input.mousePosition), Minimap.m_removeRadius * (Minimap.m_largeZoom * 2f));
+		Vector3 ScreenToWorldPoint = Minimap.ScreenToWorldPoint(Input.mousePosition);
+
+        Minimap.PinData? closestPin = Minimap.GetClosestPin(ScreenToWorldPoint, Minimap.m_removeRadius * (Minimap.m_largeZoom * 2f));
 
 		foreach (Minimap.PinData pinData in activePins.Keys)
 		{

--- a/TargetPortal/TargetPortal.cs
+++ b/TargetPortal/TargetPortal.cs
@@ -20,7 +20,7 @@ namespace TargetPortal;
 public class TargetPortal : BaseUnityPlugin
 {
 	private const string ModName = "TargetPortal";
-	private const string ModVersion = "1.1.16";
+	private const string ModVersion = "1.1.17";
 	private const string ModGUID = "org.bepinex.plugins.targetportal";
 
 	public static List<ZDO> knownPortals = new();


### PR DESCRIPTION
- Decoupling the get for the screentoworldpoint fixes the error about the method getpin not implemented
Bump version