### PR TITLE
display portal icons on small minimap and remember visibility

### DIFF
--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -13,8 +13,9 @@ public static class Map
 	public static bool Teleporting;
 	private static bool PortalAllowsAllItems;
 	private static readonly Dictionary<Minimap.PinData, ZDO> activePins = new();
+	private static bool shouldPortalsBeVisible = false;
 	private static bool[]? visibleIconTypes;
-	
+
 	[HarmonyPatch(typeof(TeleportWorldTrigger), nameof(TeleportWorldTrigger.OnTriggerEnter))]
 	private class OpenMapOnPortalEnter
 	{
@@ -39,7 +40,10 @@ public static class Map
 
 			Game.m_noMap = origNoMap;
 
-			AddPortalPins();
+			if (!shouldPortalsBeVisible)
+			{
+				AddPortalPins();
+			}
 
 			if (InventoryGui.IsVisible())
 			{
@@ -88,7 +92,10 @@ public static class Map
 	{
 		Teleporting = false;
 
-		RemovePortalPins();
+		if (!shouldPortalsBeVisible)
+		{
+			RemovePortalPins();
+		}
 
 		if (TargetPortal.hidePinsDuringPortal.Value == TargetPortal.Toggle.On)
 		{
@@ -199,20 +206,21 @@ public static class Map
 	}
 
 	[HarmonyPatch(typeof(Minimap), nameof(Minimap.Update))]
-	private static class ShowPortalIcons
+	private static class TogglePortalIcons
 	{
 		private static void Prefix()
 		{
-			if (Minimap.instance.m_mode == Minimap.MapMode.Large && TargetPortal.mapPortalIconKey.Value.IsDown())
+			if (Minimap.instance.m_mode != Minimap.MapMode.None && TargetPortal.mapPortalIconKey.Value.IsDown())
 			{
-				if (activePins.Count == 0)
-				{
-					AddPortalPins();
-				}
-				else
+				if (shouldPortalsBeVisible)
 				{
 					RemovePortalPins();
 				}
+				else
+				{
+					AddPortalPins();
+				}
+				shouldPortalsBeVisible = !shouldPortalsBeVisible;
 			}
 		}
 	}


### PR DESCRIPTION
This allows users to see portal icons on the small minimap at will using the configured key, without the need to open the large map first.

Portal icons visibility state is remembered based on user's manual toggles, that way we can avoid still properly temporarily show portal icons when entering a portal if they were not already visible, without interfering with the user's choice.