### PR TITLE
fix-broken-portals-from-update

### DIFF
--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -263,13 +263,13 @@ public static class Map
 	private static void AddPortalPins()
 	{
 		HashSet<Vector3> existingPins = new(activePins.Keys.Select(p => p.m_pos));
-		
-		string? myId = PrivilegeManager.GetNetworkUserId();
-		foreach (ZDO zdo in TargetPortal.knownPortals)
+
+		string? myId = UserInfo.GetLocalUser().UserId.m_userID;
+        foreach (ZDO zdo in TargetPortal.knownPortals)
 		{
 			TargetPortal.PortalMode mode = (TargetPortal.PortalMode)zdo.GetInt("TargetPortal PortalMode");
 			string ownerString = zdo.GetString("TargetPortal PortalOwnerId");
-			if (TargetPortal.allowNonPublicPortals.Value == TargetPortal.Toggle.Off || mode == TargetPortal.PortalMode.Public || (mode == TargetPortal.PortalMode.Admin && TargetPortal.configSync.IsAdmin) || ownerString == myId.Replace("Steam_", "") || (mode == TargetPortal.PortalMode.Group && API.GroupPlayers().Contains(PlayerReference.fromPlayerInfo(ZNet.instance.m_players.FirstOrDefault(p => p.m_host == ownerString)))) || (mode == TargetPortal.PortalMode.Guild && Guilds.API.GetOwnGuild() is { } guild && guild.Members.ContainsKey(new Guilds.PlayerReference { id = !ownerString.Contains('_') ? "Steam_" + ownerString : ownerString, name = zdo.GetString("TargetPortal PortalOwnerName") })))
+			if (TargetPortal.allowNonPublicPortals.Value == TargetPortal.Toggle.Off || mode == TargetPortal.PortalMode.Public || (mode == TargetPortal.PortalMode.Admin && TargetPortal.configSync.IsAdmin) || ownerString == myId || (mode == TargetPortal.PortalMode.Group && API.GroupPlayers().Contains(PlayerReference.fromPlayerInfo(ZNet.instance.m_players.FirstOrDefault(p => p.m_userInfo.m_id.m_userID == ownerString)))) || (mode == TargetPortal.PortalMode.Guild && Guilds.API.GetOwnGuild() is { } guild && guild.Members.ContainsKey(new Guilds.PlayerReference { id = !ownerString.Contains('_') ? "Steam_" + ownerString : ownerString, name = zdo.GetString("TargetPortal PortalOwnerName") })))
 			{
 				if (existingPins.Contains(zdo.m_position))
 				{

--- a/TargetPortal/TargetPortal.cs
+++ b/TargetPortal/TargetPortal.cs
@@ -268,7 +268,7 @@ public class TargetPortal : BaseUnityPlugin
 		{
 			if (__instance.GetComponent<Piece>() is {} piece && piece.m_nview.GetZDO() is {} zdo && !piece.IsPlacedByPlayer() && zdo.GetInt("TargetPortal PortalMode", -1) == -1)
 			{
-				SetPortalMode(zdo, SquashPortalMode((int)defaultPortalMode.Value), PrivilegeManager.GetNetworkUserId().Replace("Steam_", ""), Player.m_localPlayer.GetHoverName());
+				SetPortalMode(zdo, SquashPortalMode((int)defaultPortalMode.Value), UserInfo.GetLocalUser().UserId.m_userID, Player.m_localPlayer.GetHoverName());
 			}
 		}
 	}
@@ -289,7 +289,7 @@ public class TargetPortal : BaseUnityPlugin
 				++mode;
 				mode = SquashPortalMode(mode);
 
-				ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.Everybody, "TargetPortals ChangePortalMode", __instance.m_nview.GetZDO().m_uid, mode, PrivilegeManager.GetNetworkUserId().Replace("Steam_", ""), Player.m_localPlayer.GetHoverName());
+				ZRoutedRpc.instance.InvokeRoutedRPC(ZRoutedRpc.Everybody, "TargetPortals ChangePortalMode", __instance.m_nview.GetZDO().m_uid, mode, UserInfo.GetLocalUser().UserId.m_userID, Player.m_localPlayer.GetHoverName());
 
 				return false;
 			}


### PR DESCRIPTION
Updated `Map.cs` and `TagetPortal.cs` to use the` Splatform` `PlatformUserID` when sending messages over RPC instead of the now defunct `PrivlegeManager`.

fixes #57 