### PR TITLE
Controller support

### DIFF
--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -21,6 +21,15 @@ public static class Map
 	private static bool shouldPortalsBeVisible = false;
 	private static bool[]? visibleIconTypes;
 	private static GameObject favoriteList = null!;
+	private static readonly List<FavoriteEntry> favorites = new();
+	private static int favoriteCycleIndex = -1;
+
+	private class FavoriteEntry
+	{
+		public Minimap.PinData Pin = null!;
+		public TextMeshProUGUI Label = null!;
+		public Color LabelColor;
+	}
 
 	[HarmonyPatch(typeof(TeleportWorldTrigger), nameof(TeleportWorldTrigger.OnTriggerEnter))]
 	private class OpenMapOnPortalEnter
@@ -102,6 +111,9 @@ public static class Map
 
 	public static void CancelTeleport()
 	{
+		// Runs before the entries are torn down below, while the labels are still alive.
+		ClearFavoriteHighlight();
+
 		Teleporting = false;
 
 		if (!shouldPortalsBeVisible)
@@ -260,6 +272,46 @@ public static class Map
 		FillFavorites();
 	}
 
+	// The favorite list sits outside the map pane, so the gamepad crosshair - which is locked to the
+	// center of the screen and samples the map surface - can never be aimed at it. Instead of making
+	// the list selectable, move the map so the favorite lands under the crosshair, which leaves the
+	// existing teleport path to do the rest.
+	private static void CycleToNextFavorite()
+	{
+		if (favorites.Count == 0)
+		{
+			return;
+		}
+
+		favoriteCycleIndex = (favoriteCycleIndex + 1) % favorites.Count;
+
+		Vector3 offset = favorites[favoriteCycleIndex].Pin.m_pos - Player.m_localPlayer.transform.position;
+		Minimap.instance.m_mapOffset = new Vector3(offset.x, 0f, offset.z);
+		Minimap.instance.m_pinUpdateRequired = true;
+
+		UpdateFavoriteHighlight();
+	}
+
+	// Panning by hand moves the crosshair off whatever was jumped to, so the highlight stops being true.
+	private static void ClearFavoriteHighlight()
+	{
+		if (favoriteCycleIndex < 0)
+		{
+			return;
+		}
+
+		favoriteCycleIndex = -1;
+		UpdateFavoriteHighlight();
+	}
+
+	private static void UpdateFavoriteHighlight()
+	{
+		for (int i = 0; i < favorites.Count; ++i)
+		{
+			favorites[i].Label.color = i == favoriteCycleIndex ? Color.yellow : favorites[i].LabelColor;
+		}
+	}
+
 	// A gamepad never produces the pointer events that drive OnMapLeftClick / RemovePinUnderPointer,
 	// so the portal selection has to be read off the buttons directly.
 	[HarmonyPatch(typeof(Minimap), nameof(Minimap.Update))]
@@ -297,6 +349,14 @@ public static class Map
 			else if (ButtonDown(TargetPortal.gamepadFavoriteButton.Value) && GetClosestPortal(out _, out ZDO? portalZDO))
 			{
 				ToggleFavoritePortal(portalZDO!);
+			}
+			else if (ButtonDown(TargetPortal.gamepadCycleFavoritesButton.Value))
+			{
+				CycleToNextFavorite();
+			}
+			else if (Mathf.Abs(ZInput.GetJoyLeftStickX()) > 0.1f || Mathf.Abs(ZInput.GetJoyLeftStickY()) > 0.1f)
+			{
+				ClearFavoriteHighlight();
 			}
 		}
 	}
@@ -386,6 +446,9 @@ public static class Map
 		{
 			Object.Destroy(favoriteList.transform.GetChild(i).gameObject);
 		}
+
+		favorites.Clear();
+		favoriteCycleIndex = -1;
 	}
 
 	private static void FillFavorites()
@@ -409,8 +472,10 @@ public static class Map
 					favoriteEntry.GetComponent<HorizontalLayoutGroup>().childAlignment = TextAnchor.MiddleLeft;
 					Transform label = favoriteEntry.transform.Find("Label");
 					label.SetAsLastSibling();
-					label.GetComponent<TextMeshProUGUI>().text = pin.m_name;
+					TextMeshProUGUI labelText = label.GetComponent<TextMeshProUGUI>();
+					labelText.text = pin.m_name;
 					label.GetComponent<RectTransform>().pivot = new Vector2(0, 0.5f);
+					favorites.Add(new FavoriteEntry { Pin = pin, Label = labelText, LabelColor = labelText.color });
 					Image portalIcon = favoriteEntry.transform.Find("keyboard_hint").GetComponent<Image>();
 					portalIcon.sprite = pin.m_icon;
 					portalIcon.gameObject.AddComponent<FavoriteClicked>().Pin = pin;

--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -145,6 +145,17 @@ public static class Map
 		return false;
 	}
 
+	// Gamepads have no pointer on the map: the crosshair sits fixed at the center of the screen and
+	// the map pans underneath it. ZInput.pointerPosition keeps reporting the idle mouse position, so
+	// vanilla targets the screen center for every gamepad map action and we have to match that.
+	private static Vector3 GetMapCursorWorldPoint()
+	{
+		Vector3 screenPoint = ZInput.IsExclusiveGamepadActive()
+			? new Vector3(Screen.width / 2f, Screen.height / 2f)
+			: Input.mousePosition;
+		return Minimap.instance.ScreenToWorldPoint(screenPoint);
+	}
+
 	private static bool GetClosestPortal(out Minimap.PinData? closestPin, out ZDO? portalZDO)
 	{
 		foreach (Minimap.PinData pinData in activePins.Keys)
@@ -153,7 +164,7 @@ public static class Map
 		}
 
 		Minimap Minimap = Minimap.instance;
-		closestPin = Minimap.GetClosestPin(Minimap.ScreenToWorldPoint(Input.mousePosition), Minimap.m_removeRadius * (Minimap.m_largeZoom * 2f));
+		closestPin = Minimap.GetClosestPin(GetMapCursorWorldPoint(), Minimap.m_removeRadius * (Minimap.m_largeZoom * 2f));
 
 		foreach (Minimap.PinData pinData in activePins.Keys)
 		{
@@ -247,6 +258,66 @@ public static class Map
 		}
 		
 		FillFavorites();
+	}
+
+	// A gamepad never produces the pointer events that drive OnMapLeftClick / RemovePinUnderPointer,
+	// so the portal selection has to be read off the buttons directly.
+	[HarmonyPatch(typeof(Minimap), nameof(Minimap.Update))]
+	private static class GamepadPortalSelection
+	{
+		private static bool ButtonDown(TargetPortal.GamepadButton button) => TargetPortal.GamepadButtonName(button) is { } name && ZInput.GetButtonDown(name);
+
+		// Mirrors the takeInput check Minimap.Update makes before handling any map input.
+		private static bool TakeInput() =>
+			(Chat.instance == null || !Chat.instance.HasFocus())
+			&& !global::Console.IsVisible()
+			&& !TextInput.IsVisible()
+			&& !Menu.IsActive()
+			&& !InventoryGui.IsVisible()
+			&& (Hud.instance == null || !Hud.instance.m_buildUi.SearchFieldFocused);
+
+		private static void Prefix(Minimap __instance)
+		{
+			if (!Teleporting || __instance.m_mode != Minimap.MapMode.Large || !ZInput.IsGamepadActive())
+			{
+				return;
+			}
+
+			// The pin name dialog cannot be open here, since every route into it is blocked while
+			// Teleporting, so InTextInput covers the remaining text entry cases on its own.
+			if (ZInput.VirtualKeyboardOpen || Minimap.InTextInput() || !TakeInput())
+			{
+				return;
+			}
+
+			if (ButtonDown(TargetPortal.gamepadTeleportButton.Value))
+			{
+				HandlePortalClick(GetClosestPortal);
+			}
+			else if (ButtonDown(TargetPortal.gamepadFavoriteButton.Value) && GetClosestPortal(out _, out ZDO? portalZDO))
+			{
+				ToggleFavoritePortal(portalZDO!);
+			}
+		}
+	}
+
+	// While a portal is being picked, the map is a portal selector and not a pin editor. The mouse
+	// paths are already blocked by MapAlternativeClick, but the gamepad reaches these directly from
+	// Minimap.UpdateMap: A opens the pin name dialog and RB deletes the pin under the crosshair.
+	[HarmonyPatch(typeof(Minimap), nameof(Minimap.ShowPinNameInput))]
+	private static class BlockPinCreationWhileTeleporting
+	{
+		private static bool Prefix() => !Teleporting;
+	}
+
+	[HarmonyPatch(typeof(Minimap), nameof(Minimap.RemovePin), typeof(Vector3), typeof(float))]
+	private static class BlockPinRemovalWhileTeleporting
+	{
+		private static bool Prefix(ref bool __result)
+		{
+			__result = false;
+			return !Teleporting;
+		}
 	}
 
 	[HarmonyPatch]

--- a/TargetPortal/Map.cs
+++ b/TargetPortal/Map.cs
@@ -332,6 +332,9 @@ public static class Map
 				if (pins.TryGetValue(portal, out Minimap.PinData pin))
 				{
 					GameObject favoriteEntry = Object.Instantiate(Minimap.instance.m_largeRoot.transform.Find("KeyHints/keyboard_hints/AddPin").gameObject, favoriteList.transform);
+					// The template lives under the keyboard hint group, which is switched off while a
+					// gamepad is in use; the clone has to be shown on its own regardless.
+					favoriteEntry.SetActive(true);
 					favoriteEntry.GetComponent<HorizontalLayoutGroup>().childAlignment = TextAnchor.MiddleLeft;
 					Transform label = favoriteEntry.transform.Find("Label");
 					label.SetAsLastSibling();

--- a/TargetPortal/TargetPortal.cs
+++ b/TargetPortal/TargetPortal.cs
@@ -249,6 +249,36 @@ public class TargetPortal : BaseUnityPlugin
 		}
 	}
 
+	// Valheim resolves the interact modifier per input device and layout in Player.Update and hands
+	// the result to Interact as alt, so on a gamepad we just honour that instead of reading a
+	// keyboard key. The configured shortcut stays authoritative for keyboard and mouse.
+	private static bool PortalModeToggleRequested(bool alt)
+	{
+		if (portalModeToggleModifierKey.Value.MainKey is KeyCode.None)
+		{
+			return false;
+		}
+
+		if (ZInput.IsGamepadActive())
+		{
+			return alt;
+		}
+
+		return Input.GetKey(portalModeToggleModifierKey.Value.MainKey) && portalModeToggleModifierKey.Value.Modifiers.All(Input.GetKey);
+	}
+
+	// Mirrors the branch Player.Update takes when it computes alt, so the hint names the button that
+	// actually works. On a gamepad this resolves to a controller glyph rather than a key name.
+	private static string PortalModeToggleHint()
+	{
+		if (!ZInput.IsGamepadActive())
+		{
+			return portalModeToggleModifierKey.Value.ToString();
+		}
+
+		return Localization.instance.GetBoundKeyString(ZInput.IsNonClassicFunctionality() ? "JoyAltKeys" : "JoyAltPlace");
+	}
+
 	[HarmonyPatch(typeof(TeleportWorld), nameof(TeleportWorld.GetHoverText))]
 	private class OverrideHoverText
 	{
@@ -270,7 +300,7 @@ public class TargetPortal : BaseUnityPlugin
 				mode = PortalMode.Private;
 			}
 
-			__result = __result.Replace(Localization.instance.Localize("$piece_portal_connected"), mode + (mode is PortalMode.Public or PortalMode.Admin ? "" : $" (Owner: {__instance.m_nview.GetZDO().GetString("TargetPortal PortalOwnerName")})")) + $"\n[<b><color=yellow>{portalModeToggleModifierKey.Value}</color> + <color=yellow>{Localization.instance.Localize("$KEY_Use")}</color></b>] Toggle Mode";
+			__result = __result.Replace(Localization.instance.Localize("$piece_portal_connected"), mode + (mode is PortalMode.Public or PortalMode.Admin ? "" : $" (Owner: {__instance.m_nview.GetZDO().GetString("TargetPortal PortalOwnerName")})")) + $"\n[<b><color=yellow>{PortalModeToggleHint()}</color> + <color=yellow>{Localization.instance.Localize("$KEY_Use")}</color></b>] Toggle Mode";
 		}
 	}
 
@@ -310,14 +340,14 @@ public class TargetPortal : BaseUnityPlugin
 	[HarmonyPatch(typeof(TeleportWorld), nameof(TeleportWorld.Interact))]
 	private class TogglePortalMode
 	{
-		public static bool Prefix(TeleportWorld __instance, bool hold)
+		public static bool Prefix(TeleportWorld __instance, bool hold, bool alt)
 		{
 			if (hold || allowNonPublicPortals.Value == Toggle.Off || (limitToVanillaPortals.Value == Toggle.On && Utils.GetPrefabName(__instance.gameObject) is not "portal_wood" and not "portal_stone"))
 			{
 				return true;
 			}
 
-			if (Input.GetKey(portalModeToggleModifierKey.Value.MainKey) && portalModeToggleModifierKey.Value.Modifiers.All(Input.GetKey))
+			if (PortalModeToggleRequested(alt))
 			{
 				int mode = __instance.m_nview.GetZDO().GetInt("TargetPortal PortalMode");
 				++mode;

--- a/TargetPortal/TargetPortal.cs
+++ b/TargetPortal/TargetPortal.cs
@@ -44,6 +44,7 @@ public class TargetPortal : BaseUnityPlugin
 	public static ConfigEntry<Toggle> allowIconToggleWithoutMap = null!;
 	public static ConfigEntry<GamepadButton> gamepadTeleportButton = null!;
 	public static ConfigEntry<GamepadButton> gamepadFavoriteButton = null!;
+	public static ConfigEntry<GamepadButton> gamepadCycleFavoritesButton = null!;
 
 	private ConfigEntry<T> config<T>(string group, string name, T value, ConfigDescription description, bool synchronizedSetting = true)
 	{
@@ -89,6 +90,7 @@ public class TargetPortal : BaseUnityPlugin
 		RightBumper,
 		LeftTrigger,
 		RightTrigger,
+		DPadLeft,
 	}
 
 	// B is deliberately absent: the map uses it to close, which doubles as cancelling the teleport.
@@ -101,6 +103,8 @@ public class TargetPortal : BaseUnityPlugin
 		GamepadButton.RightBumper => "JoyRBumper",
 		GamepadButton.LeftTrigger => "JoyLTrigger",
 		GamepadButton.RightTrigger => "JoyRTrigger",
+		// The other three directions drive the vanilla pin type and icon filters on the large map.
+		GamepadButton.DPadLeft => "JoyDPadLeft",
 		_ => null,
 	};
 
@@ -122,6 +126,7 @@ public class TargetPortal : BaseUnityPlugin
 		allowIconToggleWithoutMap = config("1 - General", "Allow Icon toggle map closed", Toggle.Off, new ConfigDescription("If on, the portal icons can be toggled on and off with the hotkey, even if the map is not opened."), false);
 		gamepadTeleportButton = config("1 - General", "Gamepad teleport button", GamepadButton.A, new ConfigDescription("Gamepad button that teleports to the portal under the map crosshair."), false);
 		gamepadFavoriteButton = config("1 - General", "Gamepad favorite button", GamepadButton.Y, new ConfigDescription("Gamepad button that toggles the portal under the map crosshair as a favorite. Y is the only face button the vanilla map leaves unused."), false);
+		gamepadCycleFavoritesButton = config("1 - General", "Gamepad cycle favorites button", GamepadButton.DPadLeft, new ConfigDescription("Gamepad button that moves the map to the next favorite portal, placing it under the crosshair."), false);
 
 		Assembly assembly = Assembly.GetExecutingAssembly();
 		Harmony harmony = new(ModGUID);

--- a/TargetPortal/TargetPortal.cs
+++ b/TargetPortal/TargetPortal.cs
@@ -42,6 +42,8 @@ public class TargetPortal : BaseUnityPlugin
 	public static ConfigEntry<KeyboardShortcut> mapPortalIconKey = null!;
 	private static ConfigEntry<PortalMode> defaultPortalMode = null!;
 	public static ConfigEntry<Toggle> allowIconToggleWithoutMap = null!;
+	public static ConfigEntry<GamepadButton> gamepadTeleportButton = null!;
+	public static ConfigEntry<GamepadButton> gamepadFavoriteButton = null!;
 
 	private ConfigEntry<T> config<T>(string group, string name, T value, ConfigDescription description, bool synchronizedSetting = true)
 	{
@@ -77,6 +79,31 @@ public class TargetPortal : BaseUnityPlugin
 		Always,
 	}
 
+	public enum GamepadButton
+	{
+		Disabled,
+		A,
+		X,
+		Y,
+		LeftBumper,
+		RightBumper,
+		LeftTrigger,
+		RightTrigger,
+	}
+
+	// B is deliberately absent: the map uses it to close, which doubles as cancelling the teleport.
+	public static string? GamepadButtonName(GamepadButton button) => button switch
+	{
+		GamepadButton.A => "JoyButtonA",
+		GamepadButton.X => "JoyButtonX",
+		GamepadButton.Y => "JoyButtonY",
+		GamepadButton.LeftBumper => "JoyLBumper",
+		GamepadButton.RightBumper => "JoyRBumper",
+		GamepadButton.LeftTrigger => "JoyLTrigger",
+		GamepadButton.RightTrigger => "JoyRTrigger",
+		_ => null,
+	};
+
 	public void Awake()
 	{
 		serverConfigLocked = config("1 - General", "Lock Configuration", Toggle.On, "If on, the configuration is locked and can be changed by server admins only.");
@@ -93,6 +120,8 @@ public class TargetPortal : BaseUnityPlugin
 		ignoreItemsTeleport = config("1 - General", "Ignore item teleport restrictions", IgnoreItems.Default, new ConfigDescription("Never: Do not allow teleportation of restricted items.\nDefault: Keep vanilla behavior for portals.\nAlways: Ignore item restrictions on portals."));
 		defaultPortalMode = config("1 - General", "Default Portal mode", PortalMode.Private, new ConfigDescription("Sets the default mode for newly built portals."), false);
 		allowIconToggleWithoutMap = config("1 - General", "Allow Icon toggle map closed", Toggle.Off, new ConfigDescription("If on, the portal icons can be toggled on and off with the hotkey, even if the map is not opened."), false);
+		gamepadTeleportButton = config("1 - General", "Gamepad teleport button", GamepadButton.A, new ConfigDescription("Gamepad button that teleports to the portal under the map crosshair."), false);
+		gamepadFavoriteButton = config("1 - General", "Gamepad favorite button", GamepadButton.Y, new ConfigDescription("Gamepad button that toggles the portal under the map crosshair as a favorite. Y is the only face button the vanilla map leaves unused."), false);
 
 		Assembly assembly = Assembly.GetExecutingAssembly();
 		Harmony harmony = new(ModGUID);

--- a/TargetPortal/TargetPortal.csproj
+++ b/TargetPortal/TargetPortal.csproj
@@ -51,6 +51,29 @@
             </PropertyGroup>
         </When>
     </Choose>
+    <PropertyGroup>
+        <!-- UnityEngine.ImageConversionModule targets netstandard 2.1, which the .NET Framework 4.8
+             reference assemblies cannot satisfy: referencing it yields CS1705, and pulling in
+             netstandard 2.1 only moves the failure to CS0518 for ReadOnlySpan, because its type
+             forwards dangle off the net48 mscorlib. Resolve the BCL from the game's own Unity/Mono
+             profile instead, which is what the assemblies were built against. -->
+        <NoStdLib>true</NoStdLib>
+        <AssemblySearchPaths>{CandidateAssemblyFiles};{HintPathFromItem};$(GamePath)\valheim_Data\Managed;{TargetFrameworkDirectory};{RawFileName};$(OutDir)</AssemblySearchPaths>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="mscorlib">
+            <HintPath>$(GamePath)\valheim_Data\Managed\mscorlib.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
+        <Reference Include="netstandard">
+            <HintPath>$(GamePath)\valheim_Data\Managed\netstandard.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
+        <Reference Include="System.Memory">
+            <HintPath>$(GamePath)\valheim_Data\Managed\System.Memory.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
+    </ItemGroup>
     <ItemGroup>
         <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>$(GamePath)\BepInEx\core\0Harmony.dll</HintPath>
@@ -95,7 +118,7 @@
             <HintPath>$(GamePath)\valheim_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.ImageConversionModule">
-            <HintPath>$(GamePath)\valheim_Data\Managed\UnityEngine.ImageConversionModuleOld.dll</HintPath>
+            <HintPath>$(GamePath)\valheim_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
         </Reference>
         <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
             <HintPath>$(GamePath)\valheim_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>


### PR DESCRIPTION
## Gamepad support for the portal map

Walking into a portal opens the map with every destination pinned, but the selection was mouse-only. On a controller, pressing a button fell through to the vanilla map bindings and opened the pin-name dialog instead of teleporting.

Three separate things were wrong, so fixing the input alone would not have been enough:

- **Targeting used the mouse.** `GetClosestPortal` read `Input.mousePosition`. On a gamepad the map pans under a crosshair locked to the center of the screen, and `ZInput.pointerPosition` keeps reporting the idle mouse, so vanilla resolves every gamepad map action against the screen center. Portal selection now does the same whenever that crosshair is shown.
- **There was no input path.** A gamepad never produces the pointer events behind `OnMapLeftClick` and `RemovePinUnderPointer`. The buttons are now read from `Minimap.Update`, gated on the same conditions vanilla checks, so chat, console and menus still swallow input.
- **Vanilla competed for the buttons.** `Minimap.UpdateMap` reaches `ShowPinNameInput` and `RemovePin` straight from the gamepad, bypassing the click handlers `MapAlternativeClick` already blocks. Both are suppressed while a portal is being picked.

Favorites needed a different answer. The list is anchored outside the map pane, and the crosshair samples the map surface rather than acting as a cursor, so there is no world position under the sidebar to aim at. Instead of making the list selectable, cycling moves the map so the chosen favorite lands under the crosshair. Nothing gains a second way to teleport — the button still means whatever the crosshair is over, however it got there.

The portal mode toggle was a related but separate problem. It read `Input.GetKey` on a configured keyboard shortcut while the hover text rendered `$KEY_Use`, which resolves to a controller glyph when a gamepad is active, so the hint advertised an impossible combination like `LeftShift + X`. `Player.Update` already resolves the interact modifier for the current device and layout and passes it to `Interact` as `alt`, which the prefix was discarding.

### Commits

| | |
|---|---|
| `Fix the build against current Valheim` | **independent of the rest — see below** |
| `Show favorite portal entries when a gamepad is active` | clones inherited the hidden keyboard-hint group's inactive state |
| `Allow selecting a target portal with a gamepad` | crosshair targeting, button input, vanilla suppression |
| `Use the interact alt modifier to toggle portal mode` | honor the `alt` parameter; device-correct hint |
| `Let a gamepad reach favorite portals` | cycle the map view through favorites |

### New config

All client-side, none synchronized:

- `Gamepad teleport button` — default **A**, the button whose vanilla behavior is being replaced
- `Gamepad favorite button` — default **Y**, the only face button the vanilla map leaves unused
- `Gamepad cycle favorites button` — default **D-pad Left**, the one direction the large map leaves alone

Keyboard and mouse behavior is unchanged throughout, including a rebound mode-toggle modifier.

### On the build fix

The project referenced `UnityEngine.ImageConversionModuleOld.dll`, which no longer ships with the game, so a fresh clone could not compile at all. Repointing it is not sufficient: the current module targets netstandard 2.1, which the .NET Framework 4.8 reference assemblies cannot satisfy (`CS1705`), and referencing netstandard 2.1 only moves the failure to `CS0518` for `ReadOnlySpan`, whose type forwards dangle off the net48 mscorlib. The BCL is now resolved from the game's own Unity/Mono profile, which is what every referenced assembly was built against.

This is unrelated to controller support and is happy to be cherry-picked or split out — it is only bundled here because the branch cannot be built without it. It does not change the emitted assembly: the output references the same 16 assemblies as before, all resident in the game.

### Testing

Tested in-game on an Xbox controller: selecting portals from the map, toggling favorites, cycling to favorites, and the mode toggle hint showing the correct glyph. Each commit builds independently.

The keyboard and mouse paths are untouched by design — the gamepad handling is gated behind `ZInput.IsGamepadActive()`, the crosshair targeting behind `IsExclusiveGamepadActive()`, and the mode toggle still reads the configured shortcut whenever a gamepad is not active — but I have not re-run them since the changes.
